### PR TITLE
Duration is an integer amount of nanoseconds

### DIFF
--- a/v1-sample.json
+++ b/v1-sample.json
@@ -32,7 +32,7 @@
         "line": 12
       },
       "attempt": {
-        "duration": 1.1003003,
+        "durationInNanoseconds": 1100300300,
         "status": {
           "kind": "successful"
         }
@@ -51,7 +51,7 @@
         "line": 20
       },
       "attempt": {
-        "duration": 1.2,
+        "durationInNanoseconds": 1200000000,
         "status": {
           "kind": "quarantined",
           "originalStatus": {
@@ -64,14 +64,14 @@
     {
       "name": "Sky::Moon does not exist",
       "attempt": {
-        "duration": 1.2,
+        "durationInNanoseconds": 1200000000,
         "finishedAt": "2022-11-15T15:01:49Z",
         "status": { "kind": "successful" },
         "meta": { "env": "foo" }
       },
       "pastAttempts": [
         {
-          "duration": 1.5,
+          "durationInNanoseconds": 1500000000,
           "finishedAt": "2022-11-15T07:01:34Z",
           "status": {
             "kind": "failed",

--- a/v1/test.json
+++ b/v1/test.json
@@ -20,10 +20,10 @@
     "attempt": {
       "description": "Details about a single attempt of a test",
       "type": "object",
-      "required": ["duration", "status"],
-      "examples": [{ "duration": 100.0, "status": { "kind": "failed" } }],
+      "required": ["durationInNanoseconds", "status"],
+      "examples": [{ "durationInNanoseconds": 2500000000, "status": { "kind": "failed" } }],
       "properties": {
-        "duration": { "$ref": "#/$defs/duration" },
+        "durationInNanoseconds": { "$ref": "#/$defs/durationInNanoseconds" },
         "meta": { "$ref": "#/$defs/meta" },
         "status": { "$ref": "#/$defs/status" },
         "stderr": { "$ref": "#/$defs/stderr" },
@@ -32,9 +32,9 @@
         "finishedAt": { "$ref": "#/$defs/finishedAt" }
       }
     },
-    "duration": {
-      "description": "How long the test took to run (in seconds, with optional fractional precision)",
-      "type": ["number", "null"],
+    "durationInNanoseconds": {
+      "description": "How long the test took to run in nanoseconds",
+      "type": ["integer", "null"],
       "minimum": 0
     },
     "finishedAt": {


### PR DESCRIPTION
We have concerns about issues with consistency around floating point math. To avoid those concerns, let's standardize on nanosecond resolution and capture _that_ as an integer. An unsigned 64 bit integer gives us a little less than 600 years of duration with this: 2^64 / 1000000000 / 60 / 60 / 24 / 365.25