### PR TITLE
Add a top-level meta field to hold things not specific to tests

### DIFF
--- a/v1.json
+++ b/v1.json
@@ -11,6 +11,10 @@
       "type": "array",
       "items": { "$ref": "./v1/test.json" }
     },
+    "meta": {
+      "description": "Additional framework/library-specific metadata",
+      "type": "object"
+    },
     "otherErrors": {
       "description": "Other errors which ocurred outside of a test",
       "type": "array",


### PR DESCRIPTION
This is optional, but I've found that there are a number of situations where it would be nice to have somewhere to drop higher-level metadata that isn't test specific.